### PR TITLE
Bring employers contact form in-house, replace embedded typeform

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -97,6 +97,8 @@ configure :development do
   # custom setting for switching off analytics in development
   set :run_analytics, false
 
+  set :employers_form_endpoint, 'https://formkeep.com/f/b95fcb2be128'
+
   # turn on to view a baseline grid for setting vertical rhythm
   set :show_baseline_grid, false
 end
@@ -127,6 +129,8 @@ configure :build do
   set :run_analytics, true
 
   set :segment_key, '8NGMT5SwWiR5BvuyrpTsirX9XY8CeZ4R'
+
+  set :employers_form_endpoint, 'https://formkeep.com/f/1ae1f30c4bcf'
 
   set :show_baseline_grid, false
 

--- a/source/elements.html.haml
+++ b/source/elements.html.haml
@@ -1,3 +1,5 @@
+- @hide_from_google = true
+
 :css
   .elements { text-align: left; }
 

--- a/source/elements/forms/_inputs.html.haml
+++ b/source/elements/forms/_inputs.html.haml
@@ -1,39 +1,44 @@
+%form
+  %fieldset
+    .input-row
+      %label (Hidden)
+      %input{type: "hidden"}
 
-.input-row
-  %label (Hidden)
-  %input{type: "hidden"}
+    .input-row
+      %label Text
+      %input{type: "text"}
 
-.input-row
-  %label Text
-  %input{type: "text"}
+    .input-row
+      %label Email
+      %input{type: "email"}
 
-.input-row
-  %label Email
-  %input{type: "email"}
+    .input-row
+      %label Number
+      %input{type: "number"}
 
-.input-row
-  %label Telephone number
-  %input{type: "tel"}
+    .input-row
+      %label Telephone number
+      %input{type: "tel"}
 
-.input-row
-  %label Checkbox
-  %input{type: "checkbox"}
+    .input-row
+      %label Checkbox
+      %input{type: "checkbox"}
 
-.input-row
-  %label Textarea (with hint and wordcount)
-  %p.input-hint 
-    This is a hint about how to fill out the input.
-    %span.small You can use small text for extra hierarchy
-  %textarea
-  %p.input-feedback
-    %span This is an example. You're 450 words over the limit.
+    .input-row
+      %label Textarea (with hint and wordcount)
+      %p.input-hint 
+        This is a hint about how to fill out the input.
+        %span.small You can use small text for extra hierarchy
+      %textarea
+      %p.input-feedback
+        %span This is an example. You're 450 words over the limit.
 
-.input-row
-  %label Select
-  %select
-    %option{value: "option_1"} Option 1
-    %option{value: "option_2"} Option 2
+    .input-row
+      %label Select
+      %select
+        %option{value: "option_1"} Option 1
+        %option{value: "option_2"} Option 2
 
-.button-row
-  %p
-    %input{type: "submit", value: "Example Submit"}
+    .button-row
+      %p
+        %input{type: "submit", value: "Example Submit"}

--- a/source/employers/contact.html.haml
+++ b/source/employers/contact.html.haml
@@ -1,6 +1,4 @@
-:javascript
-  analytics.track("Viewed Employers Enquiry Form");
-
+- @hide_nav = true # Hide nav so HTML5 errors don't get hidden by it
 - @title = "Hire Developers"
 
 %section.hero-splash{style: "background-image: url(#{image_path("backgrounds/students-overhead-discussion.jpg")});"}
@@ -10,7 +8,36 @@
         %a{href: "http://www.makersacademy.com"}
           %img{src: image_path("logo/ma-white.png"), class: "logo"}
       %h1 Hire Developers
-%section.typeform
-  .typeform-widget{"data-text" => "Hire Graduates", "data-url" => "https://makersacademy.typeform.com/to/sz8vTw"}
+
+%section
+  .container
+    .form-row
+      %form#employers-form{method: "post", action: config.employers_form_endpoint}
+        %fieldset
+          %input{type: "hidden", name: "utf8", value: "✓"}
+          .input-row
+            %label{for: "numberRoles", class: "required"}
+              How many junior developer positions do you need to fill?
+            %input{type: "number", required: true, name: "numberRoles", id: "numberRoles"}
+          .input-row
+            %label{for: "teamSize", class: "required"}
+              How many people do you have on the tech team now?
+            %input{type: "number", min: 1, required: true, name: "teamSize", id: "teamSize"}
+          .input-row
+            %label{for: "companyName", class: "required"}
+              Your company's name
+            %input{type: "text", required: true, name: "companyName", id: "companyName"}
+          .input-row
+            %label{for: "name", class: "required"}
+              Your name
+            %input{type: "text", required: true, name: "name", id: "name"}
+          .input-row
+            %label{for: "email", class: "required"}
+              Email address
+            %input{type: "email", required: true, name: "email", id: "email"}
+          .button-row
+            %p
+              %input{type: "submit", value: "Start Hiring"}
+
 :javascript
-  (function(){var qs,js,q,s,d=document,gi=d.getElementById,ce=d.createElement,gt=d.getElementsByTagName,id='typef_orm',b='https://s3-eu-west-1.amazonaws.com/share.typeform.com/';if(!gi.call(d,id)){js=ce.call(d,'script');js.id=id;js.src=b+'widget.js';q=gt.call(d,'script')[0];q.parentNode.insertBefore(js,q)}})();
+  analytics.track("Viewed Employers Enquiry Form");

--- a/source/employers/thank-you.html.haml
+++ b/source/employers/thank-you.html.haml
@@ -1,0 +1,10 @@
+- @hide_from_google = true
+
+%section.hero-splash{style: "background-image: url(#{image_path("backgrounds/riz-and-tom.jpg")});"}
+  .container
+    .centered-row
+      .logo
+        %a{href: "http://www.makersacademy.com"}
+          %img{src: image_path("logo/ma-white.png"), class: "logo"}
+      %h1 Thank you!
+      %p You'll hear from someone from our team in the next few days.

--- a/source/javascripts/email_capture.js
+++ b/source/javascripts/email_capture.js
@@ -11,7 +11,7 @@
    e.g. <input type="email" data-segments="women,entrepeneurs">
  */
 
-(function ($) {
+(function ($, analytics) {
   'use strict';
 
   $.fn.emailCapture = function (options) {
@@ -60,4 +60,4 @@
       }
     });
   };
-})(jQuery);
+})(jQuery, analytics);

--- a/source/javascripts/employers_form.js
+++ b/source/javascripts/employers_form.js
@@ -1,0 +1,54 @@
+(function ($, analytics) {
+  'use strict';
+
+  $.fn.employersForm = function (options) {
+
+    return $(this).each(function(index, element) {
+      var form = $(element);
+      var email = form.find('input[type=email]');
+
+      form.on("submit", submitToAnalytics);
+
+      function submitToAnalytics(event, options) {
+
+        // Check for option to stop an infinite loop of form submissions
+        // when we trigger the form event manually below
+        if (options && options.submittedAnalytics) {
+          return;
+        }
+
+        if (email.val() !== "") {
+          event.preventDefault();
+          sendToAnalytics();
+        }
+      }
+
+      function sendToAnalytics() {
+        var properties = analyticsProperties();
+
+        analytics.alias(email.val());
+        analytics.identify(email.val(), properties);
+        analytics.track('Submitted Employers Enquiry Form', properties, function() {
+          form.trigger('submit', {submittedAnalytics: true});
+        });
+      }
+
+      function analyticsProperties() {
+        var names = form.find("#name").val().split(" ");
+
+        var values = {
+          firstName: names.shift(),
+          lastName: names.join(" ")
+        };
+
+        debugger
+
+        $.each(form.serializeArray(), function(i, field) {
+          values[field.name] = field.value;
+        });
+
+        return values;
+      }
+    });
+  };
+}(jQuery, analytics));

--- a/source/javascripts/navigation.js
+++ b/source/javascripts/navigation.js
@@ -1,4 +1,4 @@
-(function(){
+(function($, window, document){
   var $nav = $('header.navigation.auto-hide');
 
   //For showing and hiding navigation
@@ -33,4 +33,4 @@
       lastScrollTop = scrollTop;
     });
   });
-}());
+}(jQuery, window, document));

--- a/source/javascripts/sliders.js
+++ b/source/javascripts/sliders.js
@@ -34,6 +34,6 @@ $(document).ready(function() {
     });
 
     var video = $currentSlide.find('.video').data('video');
-    video.stop(); 
+    video.stop();
   });
 });

--- a/source/javascripts/tracking.js
+++ b/source/javascripts/tracking.js
@@ -1,4 +1,4 @@
-var Tracking = (function() {
+var tracking = (function(analytics) {
   function isAnchor(el) {
     el.nodeName == "A";
   }
@@ -22,4 +22,4 @@ var Tracking = (function() {
   return {
     trackClicks: trackClicks
   }
-})();
+})(analytics);

--- a/source/javascripts/videos.js
+++ b/source/javascripts/videos.js
@@ -1,10 +1,10 @@
 // Inject the YouTube Iframe API into the page
-(function addYouTubeJS() {
+(function addYouTubeJS(document) {
   var tag = document.createElement('script');
   tag.src = "https://www.youtube.com/iframe_api";
   var firstScriptTag = document.getElementsByTagName('script')[0];
   firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-})();
+})(document);
 
 // This function is called by the YouTube IFrame API when it has loaded
 // This adds an overlay to video and enables control of the video object.
@@ -24,7 +24,7 @@ function Video(iframe) {
 
 Video.prototype.play = function() {
   this._removeOverlay();
-  this.player.playVideo(); 
+  this.player.playVideo();
 };
 
 Video.prototype.stop = function() {

--- a/source/javascripts/website.js
+++ b/source/javascripts/website.js
@@ -1,19 +1,23 @@
 //= require all
+//= require employers_form
 
-var targets = {
-  ".employers-testimonials-slider .slick-prev": "Clicked Employers Testimonials Slider",
-  ".employers-testimonials-slider .slick-next": "Clicked Employers Testimonials Slider",
-  ".graduates-slider .slick-prev": "Clicked Grads Slider",
-  ".graduates-slider .slick-next": "Clicked Grads Slider",
-  ".curriculum-slider .slick-prev": "Clicked Curriculum Slider",
-  ".curriculum-slider .slick-next": "Clicked Curriculum Slider",
-  ".graduates-video": "Watched Alumni Video",
-  "[data-track]": null,
-};
+(function($, tracking) {
+  var targets = {
+    ".employers-testimonials-slider .slick-prev": "Clicked Employers Testimonials Slider",
+    ".employers-testimonials-slider .slick-next": "Clicked Employers Testimonials Slider",
+    ".graduates-slider .slick-prev": "Clicked Grads Slider",
+    ".graduates-slider .slick-next": "Clicked Grads Slider",
+    ".curriculum-slider .slick-prev": "Clicked Curriculum Slider",
+    ".curriculum-slider .slick-next": "Clicked Curriculum Slider",
+    ".graduates-video": "Watched Alumni Video",
+    "[data-track]": null,
+  };
 
-var properties = {"Course Type": "Offline"};
+  var properties = {"Course Type": "Offline"};
 
-$(document).ready(function(){
-  Tracking.trackClicks(targets, properties);
-});
+  $(document).ready(function(){
+    tracking.trackClicks(targets, properties);
 
+    $('#employers-form').employersForm();
+  });
+})(jQuery, tracking);

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -28,7 +28,8 @@
     %link{href: image_path("favicons/favicon-16x16.png"), rel: "icon", sizes: "16x16", type: "image/png"}/
   %body{class: page_classes}
     = partial :"deprecated_browser_warning"
-    = partial :"navigation"
+    - unless @hide_nav
+      = partial :"navigation"
 
     = yield
 

--- a/source/partials/_navigation.html.haml
+++ b/source/partials/_navigation.html.haml
@@ -28,9 +28,9 @@
         = link_to "Curriculum", "/curriculum.html"
       %li{ class: current_if_current_page(current_page, "/about-us/") }
         = link_to "About Us", "/about-us.html"
-      - if current_page.url == "/employers/"
+      - if current_page.url.include?("/employers")
         %li{ class: current_if_current_page(current_page, "/apply/") }
-          = link_to "Hire", "https://makersacademy.typeform.com/to/sz8vTw", class: "button button--vertical employers-button", target: "_blank", data: {track: "Viewed Employers Enquiry Form"}
+          = link_to "Hire", "/employers/contact.html", class: "button button--vertical employers-button", data: {track: "Viewed Employers Enquiry Form"}
       - else
         %li{ class: current_if_current_page(current_page, "/apply/") }
           = link_to "Apply", config.apply_form_url, class: "button button--vertical apply-button", data: {track: "Clicked Apply Page Button"}

--- a/source/sass/_forms.scss
+++ b/source/sass/_forms.scss
@@ -69,9 +69,7 @@ input[type="radio"] {
   margin-right: ma-spacing(1) / 2;
 }
 
-input[type="text"],
-input[type="tel"],
-input[type="email"] {
+#{$all-text-inputs} {
   line-height: $base-line-height * 2.5;
   height: $base-line-height * 3;
 }

--- a/source/sass/_variables.scss
+++ b/source/sass/_variables.scss
@@ -15,14 +15,6 @@ $base-spacing: $base-line-height;
 $base-button-width: 10em;
 $mobile-nav-width: em(300);
 
-@mixin ma-header($step) {
-  $header-font-size: modular-scale($step);
-  $single_line: $base-line-height / $header-font-size;
-  $lines: ceil($base-font-size / $base-line-height);
-  font-size: $header-font-size;
-  line-height: $lines * $single_line;
-  margin-bottom: $single_line;
-}
 // Colors
 // palette from http://bit.ly/1dwLGKe
 // note all alt-colors are designed to show on a blue background


### PR DESCRIPTION
This now uses our own form styles, with the data then submitting to
[FormKeep](https://formkeep.com/forms/1ae1f30c4bcf) a little SaaS from
Thoughtbot that tracks form submissions for us (login is in LastPass).

The benefit of doing it this way is we can now track things properly
using Segment, we get a specific "thank you" page when they submit and
we can see the full flow from landing page to submitting an event in
Mixpanel, with the events similarly being sent to Google Analytics and
Customer.io (which now will be auto-populated when they submit their
results).

The validation is pretty thin on the ground at the moment but that
shouldn't be a problem and if it is later we can add some more
validation (probably a good idea to add H5F so it validates in Safari).

I've also had to hide the nav bar so it doesn't get in the way of form
errors, but actually I quite like the cleaner interface and there's a
still a link to the homepage if they want to go back by clicking the
Makers Logo.

@rubenkosticki if you're happy with this we can deploy it as an MVP to
start getting data and can then edit things as we need. Please also
check along with @isoworg the copy and edit it as you need, particularly
on the thank you page and the submit button. There's also no copy above
the form, do you want to add some text there?

Closes #539