### PR TITLE
Fix non-absolute link

### DIFF
--- a/source/partials/_apply.html.haml
+++ b/source/partials/_apply.html.haml
@@ -12,7 +12,7 @@
       .button-row
         %p
           = link_to "Have hiring questions?", "http://bit.ly/meetWB", class: "button button--horizontal"
-          = link_to "Hire Developers", "employers/contact.html", class: "employers-button button button--vertical button--large", target: "_blank"
+          = link_to "Hire Developers", "/employers/contact.html", class: "employers-button button button--vertical button--large", target: "_blank"
           = link_to "Apply to Study", config.apply_form_url, class: "button button--horizontal"
 - else
 


### PR DESCRIPTION
Broken link on employers page - non-absolute page