### PR TITLE
Submit analytics for employers form on thank you page

### DIFF
--- a/source/employers/thank-you.html.haml
+++ b/source/employers/thank-you.html.haml
@@ -1,5 +1,15 @@
 - @hide_from_google = true
 
+:javascript
+  var properties = JSON.parse(window.localStorage.getItem("employerAnalyticsProperties"));
+
+  if (properties) {
+    analytics.alias(properties.email);
+    analytics.identify(properties.email, properties);
+    analytics.track('Submitted Employers Enquiry Form');
+    window.localStorage.removeItem("employerAnalyticsProperties");
+  }
+
 %section.hero-splash{style: "background-image: url(#{image_path("backgrounds/riz-and-tom.jpg")});"}
   .container
     .centered-row

--- a/source/javascripts/employers_form.js
+++ b/source/javascripts/employers_form.js
@@ -19,22 +19,14 @@
 
         if (email.val() !== "") {
           event.preventDefault();
-          sendToAnalytics();
+          storePropertiesForAnalytics();
+          submitForm();
         }
       }
 
-      function sendToAnalytics() {
-        var properties = analyticsProperties();
-
-        analytics.alias(email.val());
-        analytics.identify(email.val(), properties);
-        analytics.track('Submitted Employers Enquiry Form', properties);
-
-        // Add a 300 millisecond timeout before submitting
-        // This allows the analytics tracking to go through and is the same
-        // timeout as Segment provide in their analytics library
-        // but Segment's doesn't always seem to work
-        window.setTimeout(submitForm, 300);
+      function storePropertiesForAnalytics() {
+        var properties = JSON.stringify(analyticsProperties());
+        window.localStorage.setItem("employerAnalyticsProperties", properties);
       }
 
       function submitForm() {


### PR DESCRIPTION
This needs to be done as it's impossible to know before submitting the
form whether the analytics has completed submitting or not. This way we
take the values, put them in local storage and pull them back out on the
other side on the thank you page.

Closes #549