### PR TITLE
fixed broken links to graduates page

### DIFF
--- a/source/employers.html.haml
+++ b/source/employers.html.haml
@@ -138,7 +138,7 @@
         Check our
         = link_to "curriculum", "/curriculum.html"
         to see what our students learn. You can also find lots of
-        = link_to "case studies of graduates", "/graduates.hml"
+        = link_to "case studies of graduates", "/graduates.html"
         who now are working as software engineers at leading tech firms all over the world.
       .column
         %h4 Where are your software developers located?

--- a/source/employers/cities.html.haml
+++ b/source/employers/cities.html.haml
@@ -141,7 +141,7 @@
           Check our
         = link_to "curriculum", "/curriculum.html"
         to see what our students learn. You can also find lots of
-        = link_to "case studies of graduates", "/graduates.hml"
+        = link_to "case studies of graduates", "/graduates.html"
         who now are working as software engineers at leading tech firms all over the world.
       .column
         %h4 Where are your software developers located?

--- a/source/employers/sponsors.html.haml
+++ b/source/employers/sponsors.html.haml
@@ -139,7 +139,7 @@
         Check our
         = link_to "curriculum", "/curriculum.html"
         to see what our students learn. You can also find lots of
-        = link_to "case studies of graduates", "/graduates.hml"
+        = link_to "case studies of graduates", "/graduates.html"
         who now are working as software engineers at leading tech firms all over the world.
       .column
         %h4 Where are your software developers located?

--- a/source/employers/users.html.haml
+++ b/source/employers/users.html.haml
@@ -139,7 +139,7 @@
         Check our
         = link_to "curriculum", "/curriculum.html"
         to see what our students learn. You can also find lots of
-        = link_to "case studies of graduates", "/graduates.hml"
+        = link_to "case studies of graduates", "/graduates.html"
         who now are working as software engineers at leading tech firms all over the world.
       .column
         %h4 Where are your software developers located?


### PR DESCRIPTION
ammended "graduates.hml" to "graduates.html" in 4 links on employers, cities, sponsors and users pages.

These were 404'ing.

Followed Leo's advise and forked and fixed it. Although if I've done it all wrong I'm sure he's not to blame.