### PR TITLE
Update form styles and refactor some CSS for clarity

### DIFF
--- a/source/elements/forms/_example_form.html.haml
+++ b/source/elements/forms/_example_form.html.haml
@@ -46,34 +46,34 @@
             %p.input-feedback
               %span
 
-          .input-row
+          .input-row.input-row--centered
             %label{for: "how_did_you_hear_about_us", class: "required"}
               How did you hear about us?
-            %p.input-hint
-              Purely for marketing reasons. If you heard about us through multiple channels, choose the one that influenced your decision the most.
-            %select{required: true, name: "how_did_you_hear_about_us", id: "how_did_you_hear_about_us"}
-              %option{value: ''} Select an option&hellip;
-              %option{value: "Google", selected: @params[:how_did_you_hear_about_us] == "Google"} Google
-              %option{value: "Twitter", selected: @params[:how_did_you_hear_about_us] == "Twitter"} Twitter
-              %option{value: "Facebook", selected: @params[:how_did_you_hear_about_us] == "facebook"} Facebook
-              %option{value: "Quora", selected: @params[:how_did_you_hear_about_us] == "Quora"} Quora
-              %option{value: "The Student Room", selected: @params[:how_did_you_hear_about_us] == "The Student Room"} The Student Room
-              %option{value: "Don't Panic", selected: @params[:how_did_you_hear_about_us] == "Don't Panic"} Don't Panic
-              %option{value: "Techendo", selected: @params[:how_did_you_hear_about_us] == "Techendo"} Techendo
-              %option{value: "Switchup", selected: @params[:how_did_you_hear_about_us] == "Switchup"} SwitchUp
-              %option{value: "Bootcamper.io", selected: @params[:how_did_you_hear_about_us] == "Bootcamper.io"} Bootcamper.io
-              %option{value: "Guardian coverage", selected: @params[:how_did_you_hear_about_us] == "Guardian coverage"} Guardian coverage
-              %option{value: "Telegraph coverage", selected: @params[:how_did_you_hear_about_us] == "Telegraph coverage"} Telegraph coverage
-              %option{value: "Independent coverage", selected: @params[:how_did_you_hear_about_us] == "Independent coverage"} Independent coverage
-              %option{value: "Bbc coverage", selected: @params[:how_did_you_hear_about_us] == "BBC coverage"} BBC coverage
-              %option{value: "Sky coverage", selected: @params[:how_did_you_hear_about_us] == "Sky coverage"} Sky coverage
-              %option{value: "Codecourses.co.uk", selected: @params[:how_did_you_hear_about_us] == "Codecourses.co.uk"} Codecourses.co.uk
-              %option{value: "One Month", selected: @params[:how_did_you_hear_about_us] == "One Month"} One Month
-              %option{value: "Reed", selected: @params[:how_did_you_hear_about_us] == "Reed"} Reed
-              %option{value: "Course Report", selected: @params[:how_did_you_hear_about_us] == "Course Report"} Course Report
-              %option{value: "Other media coverage", selected: @params[:how_did_you_hear_about_us] == "Other media coverage"} Other media coverage
-              %option{value: "Alumnus recommendation", selected: @params[:how_did_you_hear_about_us] == "Alumnus recommendation"} Alumnus recommendation
-              %option{value: "Someone else's recommendation", selected: @params[:how_did_you_hear_about_us] == "Someone else's recommendation"} Someone else's recommendation
+              %p.input-hint
+                Purely for marketing reasons. If you heard about us through multiple channels, choose the one that influenced your decision the most.
+              %select{required: true, name: "how_did_you_hear_about_us", id: "how_did_you_hear_about_us"}
+                %option{value: ''} Select an option&hellip;
+                %option{value: "Google", selected: @params[:how_did_you_hear_about_us] == "Google"} Google
+                %option{value: "Twitter", selected: @params[:how_did_you_hear_about_us] == "Twitter"} Twitter
+                %option{value: "Facebook", selected: @params[:how_did_you_hear_about_us] == "facebook"} Facebook
+                %option{value: "Quora", selected: @params[:how_did_you_hear_about_us] == "Quora"} Quora
+                %option{value: "The Student Room", selected: @params[:how_did_you_hear_about_us] == "The Student Room"} The Student Room
+                %option{value: "Don't Panic", selected: @params[:how_did_you_hear_about_us] == "Don't Panic"} Don't Panic
+                %option{value: "Techendo", selected: @params[:how_did_you_hear_about_us] == "Techendo"} Techendo
+                %option{value: "Switchup", selected: @params[:how_did_you_hear_about_us] == "Switchup"} SwitchUp
+                %option{value: "Bootcamper.io", selected: @params[:how_did_you_hear_about_us] == "Bootcamper.io"} Bootcamper.io
+                %option{value: "Guardian coverage", selected: @params[:how_did_you_hear_about_us] == "Guardian coverage"} Guardian coverage
+                %option{value: "Telegraph coverage", selected: @params[:how_did_you_hear_about_us] == "Telegraph coverage"} Telegraph coverage
+                %option{value: "Independent coverage", selected: @params[:how_did_you_hear_about_us] == "Independent coverage"} Independent coverage
+                %option{value: "Bbc coverage", selected: @params[:how_did_you_hear_about_us] == "BBC coverage"} BBC coverage
+                %option{value: "Sky coverage", selected: @params[:how_did_you_hear_about_us] == "Sky coverage"} Sky coverage
+                %option{value: "Codecourses.co.uk", selected: @params[:how_did_you_hear_about_us] == "Codecourses.co.uk"} Codecourses.co.uk
+                %option{value: "One Month", selected: @params[:how_did_you_hear_about_us] == "One Month"} One Month
+                %option{value: "Reed", selected: @params[:how_did_you_hear_about_us] == "Reed"} Reed
+                %option{value: "Course Report", selected: @params[:how_did_you_hear_about_us] == "Course Report"} Course Report
+                %option{value: "Other media coverage", selected: @params[:how_did_you_hear_about_us] == "Other media coverage"} Other media coverage
+                %option{value: "Alumnus recommendation", selected: @params[:how_did_you_hear_about_us] == "Alumnus recommendation"} Alumnus recommendation
+                %option{value: "Someone else's recommendation", selected: @params[:how_did_you_hear_about_us] == "Someone else's recommendation"} Someone else's recommendation
           .button-row
             %p
               %input{type: "submit", value: "Apply"}

--- a/source/elements/forms/_inputs.html.haml
+++ b/source/elements/forms/_inputs.html.haml
@@ -25,8 +25,9 @@
       %input{type: "tel", class: "intl-tel-input"}
 
     .input-row
-      %label Checkbox
-      %input{type: "checkbox"}
+      %label 
+        Checkbox
+        %input{type: "checkbox"}
 
     .input-row
       %label Textarea (with hint and wordcount)
@@ -38,10 +39,18 @@
         %span This is an example. You're 450 words over the limit.
 
     .input-row
-      %label Select
-      %select
-        %option{value: "option_1"} Option 1
-        %option{value: "option_2"} Option 2
+      %label 
+        Select
+        %select
+          %option{value: "option_1"} Option 1
+          %option{value: "option_2"} Option 2
+
+    .input-row.input-row--centered
+      %label 
+        Select (centered)
+        %select
+          %option{value: "option_3"} Option 3
+          %option{value: "option_4"} Option 4
 
     .button-row
       %p

--- a/source/sass/_definition_lists.scss
+++ b/source/sass/_definition_lists.scss
@@ -45,6 +45,10 @@
   .definition {
     text-align: left;
 
+    p {
+      text-align: left;
+    }
+
     &:last-child {
       margin-bottom: modular-scale(3);
     }

--- a/source/sass/_footer.scss
+++ b/source/sass/_footer.scss
@@ -42,6 +42,10 @@ footer {
       font-style: normal;
       line-height: inherit;
 
+      p {
+        text-align: center;
+      }
+
       span {
         font-size: modular-scale(-1);
       }

--- a/source/sass/_forms.scss
+++ b/source/sass/_forms.scss
@@ -163,7 +163,7 @@ form.alt {
 
 form {
   .button-row p {
-    text-align: center;
+    text-align: center !important;
   }
 }
 

--- a/source/sass/_forms.scss
+++ b/source/sass/_forms.scss
@@ -7,19 +7,18 @@ fieldset {
   }
 }
 
+legend {
+  margin: 0 auto;
+}
+
 input,
 label,
-textarea,
-select {
+textarea {
   display: block;
-  font-family: $base-font-family;
-  font-size: $base-font-size;
-  line-height: $base-line-height;
 }
 
 label {
-  font-weight: 600;
-  margin-bottom: $base-line-height * 0.4;
+  @include tiny-header(left);
   abbr {
     display: none;
   }
@@ -33,15 +32,19 @@ td {
 
 #{$all-text-inputs},
 select[multiple=multiple],
+select,
 textarea {
   border: $base-border;
-  border-radius: 8px;
+  border-radius: $base-border-radius * 4;
   box-shadow: $form-box-shadow;
   box-sizing: border-box;
   margin-bottom: ma-spacing(1);
-  padding: 0 $base-line-height;
+  padding: 0 ($base-line-height / 2);
   transition: border-color;
   width: 100%;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
+
   &:hover {
     border-color: darken($base-border-color, 10%);
   }
@@ -53,8 +56,8 @@ textarea {
 }
 
 #{$all-text-inputs} {
-  line-height: $base-line-height * 2.5;
-  height: $base-line-height * 3;
+  line-height: $base-line-height;
+  height: $base-line-height * 2;
 }
 
 textarea {
@@ -93,6 +96,10 @@ input[type="file"] {
   width: 100%;
 }
 
+input[type="submit"] {
+  border-color: $brand-primary-color;
+}
+
 select {
   margin-bottom: ma-spacing(1);
   max-width: 100%;
@@ -128,21 +135,50 @@ form.alt {
   }
 }
 .input-hint {
+  text-align: left;
   .small {
     display: block;
     margin-bottom: -1 * $base-line-height / 2;
   }
 }
+
 .input-row {
-  select {
-    display: block;
-    margin: 0 auto;
-    margin-bottom: $base-line-height;
+  max-width: $paragraph-max-width + (2 * $base-spacing);
+  padding-right: $base-spacing;
+  padding-left: $base-spacing;
+  margin: 0 auto;
+
+  .input-hint {
+    margin: 0 0 $base-spacing;
+  }
+
+  &--centered {
+    text-align: center;
+
+    label {
+      text-align: center;
+    }
   }
 }
 
 form {
   .button-row p {
     text-align: center;
+  }
+}
+
+.intl-tel-input {
+  margin-bottom: ma-spacing(1);
+  .selected-flag:focus {
+    outline: none;
+  }
+
+  .country-list {
+    border-radius: $base-border-radius * 4;
+    border-width: 2px;
+    margin: -1px 0 0 -1px;
+    border-top-right-radius: 0;
+    border-color: $light-gray;
+    box-shadow: 1px 2px 2px 0px rgba(0,0,0,0.2);
   }
 }

--- a/source/sass/_layout.scss
+++ b/source/sass/_layout.scss
@@ -91,12 +91,13 @@ hr {
 
 .shift-to-bottom {
   position: absolute;
-  bottom: modular-scale(2);
+  bottom: 0;
   left: modular-scale(2);
   right: modular-scale(2);
   z-index: 1;
   @include media($desktop) {
     position: static;
+    bottom: modular-scale(2);
   }
 }
 

--- a/source/sass/_mixins.scss
+++ b/source/sass/_mixins.scss
@@ -110,3 +110,24 @@
     background-color: $light-gray;
   }
 }
+
+@mixin body-text($alignment: left) {
+  font-family: $base-font-family;
+  font-size: $base-font-size;
+  letter-spacing: normal;
+  text-align: $alignment;
+  font-weight: $base-font-weight;
+  text-transform: none;
+}
+
+@mixin tiny-header($alignment: center) {
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-size: $small-font-size;
+  text-align: $alignment;
+  font-weight: $base-font-weight;
+
+  @include media($mobile) {
+    font-size: (3 * $small-font-size) / 4;
+  }
+}

--- a/source/sass/_rows.scss
+++ b/source/sass/_rows.scss
@@ -17,8 +17,9 @@
   }
 
   p {
+    @include body-text(center);
     margin: 0 auto ma-spacing(1);
-    max-width: em(580);
+    max-width: $paragraph-max-width;
     &:last-child {
       margin-bottom: 0;
     }
@@ -33,6 +34,9 @@
 
 .button-row {
   @include ma-row;
+  p {
+    text-align: center;
+  }
   #{$all-button-inputs}, .button, .button--horizontal, .button--vertical {
     display: block;
     margin: 0 auto;

--- a/source/sass/_tables.scss
+++ b/source/sass/_tables.scss
@@ -14,7 +14,7 @@ th {
 
 thead {
   th {
-    text-align: center;
+    @include tiny-header;
   }
 }
 
@@ -108,11 +108,18 @@ table.responsive-table {
 }
 
 .radio-table {
+  thead th {
+    @include tiny-header;
+  }
+
   tbody tr {
     &:hover {
       background-color: lighten($light-gray, 8%);
       cursor: pointer;
     }
+  }
+  td, label {
+    @include body-text(center);
   }
 }
 

--- a/source/sass/_typography.scss
+++ b/source/sass/_typography.scss
@@ -72,16 +72,14 @@ h4 {
 }
 
 p {
+  @include body-text(center);
+
   margin: 0 0 $base-spacing;
-  font-size: $base-font-size;
-  font-weight: 400;
   &:last-child {
     margin-bottom: 0;
   }
 
   @include media($desktop) {
-    font-size: $base-font-size;
-
     &.leader {
       font-size: modular-scale(1);
       line-height: 1.25 * $base-line-height;
@@ -89,8 +87,9 @@ p {
   }
 
 }
+
 .small {
-  font-size: $base-font-size / $modular-scale-ratio;
+  font-size: $small-font-size;
   color: lighten($dark-gray, 15%);
 }
 
@@ -173,13 +172,18 @@ picture {
 // General-purpose copy, including titles
 .copy {
   text-align: center;
+  p {
+    text-align: center !important;
+  }
 }
 
 .copy--left {
   @extend .copy;
-
   @include media($desktop) {
     text-align: left;
+    p {
+      text-align: left !important;
+    }
   }
 }
 
@@ -187,6 +191,9 @@ picture {
   @extend .copy;
   @include media($desktop) {
     text-align: right;
+    p {
+      text-align: right !important;
+    }
   }
 }
 

--- a/source/sass/_variables.scss
+++ b/source/sass/_variables.scss
@@ -3,6 +3,9 @@ $futura: "futura-pt", Futura, $helvetica;
 $base-font-family: $futura;
 $heading-font-family: $base-font-family;
 $base-font-size: 18px;
+$small-font-size: $base-font-size / $modular-scale-ratio;
+$paragraph-max-width: rem(580);
+$base-font-weight: 400;
 
 // Vertical rhythm set-up
 $em-base: $base-font-size;

--- a/source/sass/components/_article.scss
+++ b/source/sass/components/_article.scss
@@ -32,10 +32,10 @@
     }
     p.date {
       color: transparentize($base-font-color, 0.6);
-      font-size: modular-scale(-1);
+      @include tiny-header;
     }
     p {
-      max-width: em(580);
+      max-width: $paragraph-max-width;
       font-weight: 400;
       letter-spacing: 1;
       span {
@@ -55,7 +55,7 @@
       width: 3em;
     }
     p.author {
-      font-style: italic;
+      @include tiny-header;
     }
   }
   & + .container > .button-row {

--- a/source/sass/components/_comparison_table.scss
+++ b/source/sass/components/_comparison_table.scss
@@ -3,6 +3,10 @@
   @include media($tablet-down) {
     display: none;
   }
+
+  * {
+    text-align: center;
+  }
 }
 
 .comparison-table--mobile {
@@ -11,6 +15,10 @@
     display: table;
     border-collapse: collapse;
     margin-bottom: -1 * ma-spacing(2);
+  }
+
+  .comparison-key {
+    @include tiny-header;
   }
 }
 
@@ -25,6 +33,9 @@
 
 .comparison-wrap--keys {
   box-shadow: none;
+  .comparison-key {
+    @include tiny-header;
+  }
 }
 
 .comparison-wrap--values {


### PR DESCRIPTION
Some new styles for forms, and some slight modification to table styles to bring them in line with the new form styles.

Two important things to note:

- HTML for `select` and `input[type=checkbox]` elements has changed slightly. Notably, they must now be embedded within their labels. This also conforms with accessibility best practice for forms
- Any `.input-hint`s attached to the above form elements should also live inside the label.