### PR TITLE
Updates link to help.makersacademy.com

### DIFF
--- a/source/about-us.html.haml
+++ b/source/about-us.html.haml
@@ -29,6 +29,6 @@
     %h3 Looking for our FAQs?
     %p They've moved!
     .button-row.centered
-      =link_to "Help Centre", "https://help.makersacademy.com", class: "button button--horizontal"
+      =link_to "Help Centre", "http://help.makersacademy.com", class: "button button--horizontal"
 
 = partial :"primary_call_to_action", locals: {about_us: true}


### PR DESCRIPTION
Changed the link to help.makersacademy.com to be HTTP instead of HTTPS because this page is handled by GrooveHQ and it was causing users to get a privacy error whenever they clicked on the link.

Closes #847 