### PR TITLE
Bump bower version 2.9.0 -> 2.10.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "makers_styles",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "authors": [
     "Makers Engineering <dev@makersacademy.com>"
   ],


### PR DESCRIPTION
Turns out many other of our websites use this repo as a bower package and so we'll need to release it as one. This is the first step of that.